### PR TITLE
Fix summary report for (re) and (glob) keywords

### DIFF
--- a/.github/workflows/grill.yml
+++ b/.github/workflows/grill.yml
@@ -1,0 +1,22 @@
+name: grill
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_go117:
+    name: 'go 1.17.x'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.7
+    - name: Build
+      run: go build -o cram -v .
+    - test: Test
+      run: bash test.sh

--- a/README.md
+++ b/README.md
@@ -17,5 +17,8 @@ WONTFIX:
   * PCRE is not supported. Instead, Go's regexp language is.
   * Short flags are not supported.
 
+Additional differences:
+  * glob keyword: Use `**` to glob across directory separators.
+
 There are probably lots of bugs at this point, bug reports and test cases would
 be appreciated.

--- a/examples/env.t
+++ b/examples/env.t
@@ -25,9 +25,8 @@ Check environment variables:
   skip.t
   test.t
 
-# TODO
-#  $ echo "$TESTFILE"
-#  env.t
+  $ echo "$TESTFILE"
+  env.t
 
   $ pwd
   **/grilltests*/env.t (glob)

--- a/examples/env.t
+++ b/examples/env.t
@@ -1,0 +1,33 @@
+Check environment variables:
+
+  $ echo "$LANG"
+  C
+  $ echo "$LC_ALL"
+  C
+  $ echo "$LANGUAGE"
+  C
+  $ echo "$TZ"
+  GMT
+  $ echo "$CDPATH"
+  
+  $ echo "$GREP_OPTIONS"
+  
+  $ echo "$CRAMTMP"
+  .+ (re)
+  $ echo "$TESTDIR"
+  **/examples (glob)
+  $ ls "$TESTDIR"
+  bare.t
+  empty.t
+  env.t
+  fail.t
+  missingeol.t
+  skip.t
+  test.t
+
+# TODO
+#  $ echo "$TESTFILE"
+#  env.t
+
+  $ pwd
+  **/grilltests*/env.t (glob)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/echlebek/grill
+
+go 1.17
+
+require (
+	github.com/mb0/diff v0.0.0-20131118162322-d8d9a906c24d
+	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mb0/diff v0.0.0-20131118162322-d8d9a906c24d h1:eAS2t2Vy+6psf9LZ4T5WXWsbkBt3Tu5PWekJy5AGyEU=
+github.com/mb0/diff v0.0.0-20131118162322-d8d9a906c24d/go.mod h1:3YMHqrw2Qu3Liy82v4QdAG17e9k91HZ7w3hqlpWqhDo=
+github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4 h1:NK3O7S5FRD/wj7ORQ5C3Mx1STpyEMuFe+/F0Lakd1Nk=
+github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4/go.mod h1:FqD3ES5hx6zpzDainDaHgkTIqrPaI9uX4CVWqYZoQjY=

--- a/grill/diff.go
+++ b/grill/diff.go
@@ -3,20 +3,23 @@ package grill
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"regexp"
 
 	"github.com/mb0/diff"
+	"github.com/mb0/glob"
 )
 
+// TODO so far unused
 const ContextLines = 5
 
-type FuzzyMatchData struct {
-	a [][]byte
-	b [][]byte
+// DiffData contains output difference data for a single test case.
+type DiffData struct {
+	a       [][]byte
+	b       [][]byte
+	changes []diff.Change
 }
 
-func (f FuzzyMatchData) Equal(i, j int) bool {
+func (f DiffData) Equal(i, j int) bool {
 	a := f.a[i]
 	b := f.b[j]
 
@@ -38,32 +41,40 @@ func matchRegexp(a, b []byte) bool {
 }
 
 func matchGlob(a, b []byte) bool {
-	match, err := filepath.Match(string(a), string(b))
+	match, err := glob.Match(string(a), string(b))
 	if err != nil {
 		return bytes.Equal(a, b)
 	}
 	return match
 }
 
-func Diff(a, b []byte, name string) []byte {
+// NewDiff computes difference between two slices of text lines.
+func NewDiff(a, b []byte) DiffData {
 	alines := bytes.Split(a, []byte("\n"))
 	blines := bytes.Split(b, []byte("\n"))
-	w := new(bytes.Buffer)
 
-	d := FuzzyMatchData{alines, blines}
+	d := DiffData{a: alines, b: blines}
+	d.changes = diff.Diff(len(d.a), len(d.b), d)
 
-	changes := diff.Diff(len(d.a), len(d.b), d)
-	if len(changes) == 0 {
+	return d
+}
+
+// ToString formats the diff data into a unified diff.
+func (d DiffData) ToString(name string) []byte {
+	if len(d.changes) == 0 {
 		return nil
 	}
+
+	w := new(bytes.Buffer)
+
 	fmt.Fprint(w, "--- ", name, "\n")
 	fmt.Fprint(w, "+++ ", name, ".err", "\n")
 
-	for _, c := range changes {
+	for _, c := range d.changes {
 		fmt.Fprintf(w, "@@ -%d,%d +%d,%d @@\n", c.A+1, c.Del+1, c.B+1, c.Ins+1)
 
-		delLines := alines[c.A : c.A+c.Del]
-		insLines := blines[c.B : c.B+c.Ins]
+		delLines := d.a[c.A : c.A+c.Del]
+		insLines := d.b[c.B : c.B+c.Ins]
 
 		for _, line := range delLines {
 			fmt.Fprint(w, "-  ", string(line), "\n")

--- a/grill/runner.go
+++ b/grill/runner.go
@@ -97,15 +97,17 @@ func (t *Test) Run(ctx TestContext) error {
 		return err
 	}
 
+	basename := filepath.Base(t.Filepath)
+
 	// Create working directory for individual source file
-	cmd.Dir = filepath.Join(ctx.WorkDir, filepath.Base(t.Filepath))
+	cmd.Dir = filepath.Join(ctx.WorkDir, basename)
 	if err := os.Mkdir(cmd.Dir, 0700); err != nil && !os.IsExist(err) {
 		return err
 	}
 
 	cmd.Env = append(ctx.Environ, []string{
 		// TODO escape spaces in paths?
-		fmt.Sprintf("TESTFILE=%s", t.Filepath),
+		fmt.Sprintf("TESTFILE=%s", basename),
 		fmt.Sprintf("TESTDIR=%s", testdir),
 	}...)
 

--- a/grill/runner.go
+++ b/grill/runner.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 )
@@ -25,34 +26,43 @@ type TestContext struct {
 // Default environment variables set by grill.
 const DefaultEnvironment = `LANG=C
 LC_ALL=C
-LANGAUGE=C
+LANGUAGE=C
 TZ=GMT
 COLUMNS=80
-CDPATH=''
-GREP_OPTIONS=''`
+CDPATH=
+GREP_OPTIONS=`
 
 // DefaultTestContext creates a new TestContext with environment defaults.
-func DefaultTestContext(testdir, shell string, stdout, stderr io.Writer) (TestContext, error) {
-	// TODO support TESTFILE elsewhere
-	td, err := ioutil.TempDir("", "grill")
+//
+// The function is meant to be called once per grill command invocation and
+// creates two things:
+//
+//  - An overall working directory root in default TMPDIR
+//  - A single local {workdir}/tmp temporary directory for all of the executed tests
+//
+// As tests execute later on, they will create named sub-directories
+// that will serve as their individual working directories.
+func DefaultTestContext(shell string, stdout, stderr io.Writer) (TestContext, error) {
+	wd, err := ioutil.TempDir("", "grilltests")
+	td := filepath.Join(wd, "tmp")
+	if err := os.Mkdir(td, 0700); err != nil {
+		return TestContext{}, err
+	}
+
 	env := []string{
 		fmt.Sprintf("TMPDIR=%s", td),
 		fmt.Sprintf("TEMP=%s", td),
 		fmt.Sprintf("TMP=%s", td),
 		fmt.Sprintf("GRILLTMP=%s", td),
-		fmt.Sprintf("TESTDIR=%s", testdir),
+		fmt.Sprintf("CRAMTMP=%s", td),
 		fmt.Sprintf("TESTSHELL=%q", shell),
-		"LANG=C",
-		"LC_ALL=C",
-		"LANGAUGE=C",
-		"TZ=GMT",
-		"COLUMNS=80",
-		"CDPATH=''",
-		"GREP_OPTIONS=''",
 	}
+	// TODO Handle --preserve-env flag
+	env = append(env, strings.Split(DefaultEnvironment, "\n")...)
+	env = append(env, os.Environ()...)
 	return TestContext{
 		Shell:   strings.Split(shell, " "),
-		WorkDir: td,
+		WorkDir: wd,
 		Environ: env,
 		Stdout:  stdout,
 		Stderr:  stderr,
@@ -80,11 +90,26 @@ func (t *Test) Run(ctx TestContext) error {
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 	cmd.Stdin = t.Command()
-	cmd.Env = ctx.Environ
-	cmd.Dir = ctx.WorkDir
 
-	err := cmd.Start()
+	// Add test specific variables
+	testdir, err := filepath.Abs(filepath.Dir(t.Filepath))
 	if err != nil {
+		return err
+	}
+
+	// Create working directory for individual source file
+	cmd.Dir = filepath.Join(ctx.WorkDir, filepath.Base(t.Filepath))
+	if err := os.Mkdir(cmd.Dir, 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	cmd.Env = append(ctx.Environ, []string{
+		// TODO escape spaces in paths?
+		fmt.Sprintf("TESTFILE=%s", t.Filepath),
+		fmt.Sprintf("TESTDIR=%s", testdir),
+	}...)
+
+	if err = cmd.Start(); err != nil {
 		return fmt.Errorf("couldn't run command: %s", err)
 	}
 	if err = cmd.Wait(); err != nil {
@@ -103,6 +128,8 @@ func (t *Test) Run(ctx TestContext) error {
 	if len(t.obsResults[len(t.obsResults)-1]) == 0 {
 		t.obsResults = t.obsResults[:len(t.obsResults)-1]
 	}
+
+	t.diff = NewDiff([]byte(t.ExpectedResults()), []byte(t.ObservedResults()))
 
 	if t.Failed() {
 		if _, err := ctx.Stdout.Write([]byte{'!'}); err != nil {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func readTestSuite(path string) (ts *grill.TestSuite, err error) {
 
 	for err == nil {
 		err = r.Read(&t)
+
+		t.Filepath = path
 		tests = append(tests, t)
 	}
 	if err != io.EOF && err != nil {
@@ -57,7 +59,8 @@ func Main(a []string, stdout, stderr io.Writer) int {
 		fmt.Fprint(stderr, "Usage: grill [OPTIONS] TESTS...\n")
 		return 2
 	}
-	context, err := grill.DefaultTestContext(".", "bash", stdout, stderr)
+
+	context, err := grill.DefaultTestContext("bash", stdout, stderr)
 	if err != nil {
 		log.Println(err)
 		return 1
@@ -70,6 +73,7 @@ func Main(a []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			rc = 1
 			log.Println(err)
+			continue
 		}
 
 		for i := range suite.Tests {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+go test .
+
+rm -f examples/*.err
+./cram --quiet examples/env.t


### PR DESCRIPTION
Previously, Test.Failed() checked for direct equality between expected
and observed output and so even tho there might've been no difference for
lines with keywords, the summary and progress bar still reported failed tests.
Fix that by having Failed() use computed diff.

Use glob library that supports globbing across separator chars, since
this is a common use case.

Additionally, fix errorneous quoting for some of the environment variables.
Add CRAMTMP for backwards compatibility with existing Cram tests.

Start adding examples and test cases from original cram repo.