### PR TITLE
Implement --keep-tmpdir option.

### DIFF
--- a/cmd/grill/main.go
+++ b/cmd/grill/main.go
@@ -94,5 +94,14 @@ func Main(a []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	if *opts.keepTmpdir {
+		_, err := fmt.Fprintf(stderr, "# Kept temporary directory: %s\n", context.WorkDir)
+		if err != nil {
+			log.Println(err)
+		}
+	} else {
+		context.Cleanup()
+	}
+
 	return rc
 }

--- a/cmd/grill/main.go
+++ b/cmd/grill/main.go
@@ -97,7 +97,7 @@ func Main(a []string, stdout, stderr io.Writer) int {
 	if *opts.keepTmpdir {
 		_, err := fmt.Fprintf(stderr, "# Kept temporary directory: %s\n", context.WorkDir)
 		if err != nil {
-			log.Println(err)
+			panic(err)
 		}
 	} else {
 		context.Cleanup()

--- a/examples/env.t
+++ b/examples/env.t
@@ -31,4 +31,4 @@ Check environment variables:
   env.t
 
   $ pwd
-  **/grilltests*/env.t (glob)
+  **/grilltests*/examples/env.t (glob)

--- a/tests/keeptmpdir.t
+++ b/tests/keeptmpdir.t
@@ -1,0 +1,19 @@
+--keep-tmpdir leaves behind temporary directories. Ensure
+temporary directories are distinct for .t files with the
+same name but in different branches.
+
+  $ mkdir -p sub1/sub2
+  $ echo '  $ true' > sub1/abc.t
+  $ echo '  $ true' > sub1/sub2/abc.t
+  $ grill --keep-tmpdir sub1/abc.t sub1/sub2/abc.t >log 2>&1
+
+  $ cat log
+  .
+  # Ran 1 test, 0 skipped, 0 failed.
+  .
+  # Ran 1 test, 0 skipped, 0 failed.
+  # Kept temporary directory: **/grilltests*/** (glob)
+
+  $ find `cat log | grep -oP "(?<=directory: ).*"` -name '*.t'
+  **/grilltests*/sub1/sub2/abc.t (glob)
+  **/grilltests*/sub1/abc.t (glob)


### PR DESCRIPTION
Preserve relative test file tree structure when creating temporary working directories.