### PR TITLE
Report single status for entire suite; enable -quiet flag.

### DIFF
--- a/cmd/grill/flags.go
+++ b/cmd/grill/flags.go
@@ -23,14 +23,14 @@ var opts = struct {
 	indent      *int
 }{
 	version:     flags.Bool("version", false, "show version information and exit"),
-	quiet:       flags.Bool("quiet", false, "don't print diffs (unsupported)"),
+	quiet:       flags.Bool("quiet", false, "don't print diffs"),
 	verbose:     flags.Bool("verbose", false, "show filenames and test status (unsupported)"),
 	interactive: flags.Bool("interactive", false, "interactively merge changed test output (unsupported)"),
 	debug:       flags.Bool("debug", false, "write script output directly to the terminal (unsupported)"),
 	yes:         flags.Bool("yes", false, "answer yes to all questions (unsupported)"),
 	no:          flags.Bool("no", false, "answer no to all questions (unsupported)"),
-	preserveEnv: flags.Bool("preserve-env", false, "don't reset common environment variables (unsupported)"),
-	keepTmpdir:  flags.Bool("keep-tmpdir", false, "keep temporary directories (unsupported)"),
+	preserveEnv: flags.Bool("preserve-env", false, "don't reset common environment variables"),
+	keepTmpdir:  flags.Bool("keep-tmpdir", false, "keep temporary directories"),
 	shell:       flags.String("shell", "/bin/sh", "shell to use for running tests (unsupported)"),
 	shellOpts:   flags.String("shell-opts", "", "arguments to invoke shell with (unsupported)"),
 	xunitFile:   flags.String("xunit-file", "", "path to write xUnit XML output (unsupported)"),

--- a/internal/grill/runner_test.go
+++ b/internal/grill/runner_test.go
@@ -43,12 +43,7 @@ func TestRunTest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := stdout.String(), "."; got != want {
-		t.Errorf("bad test status output: got %q, want %q", got, want)
-	}
-
 	if got, want := test.ExpectedResults(), test.ObservedResults(); got != want {
 		t.Errorf("bad test output: got %q, want %q", got, want)
 	}
-
 }

--- a/tests/keeptmpdir.t
+++ b/tests/keeptmpdir.t
@@ -8,10 +8,8 @@ same name but in different branches.
   $ grill --keep-tmpdir sub1/abc.t sub1/sub2/abc.t >log 2>&1
 
   $ cat log
-  .
-  # Ran 1 test, 0 skipped, 0 failed.
-  .
-  # Ran 1 test, 0 skipped, 0 failed.
+  ..
+  # Ran 2 tests, 0 skipped, 0 failed.
   # Kept temporary directory: **/grilltests*/** (glob)
 
   $ find `cat log | grep -oP "(?<=directory: ).*"` -name '*.t'

--- a/tests/status.t
+++ b/tests/status.t
@@ -1,0 +1,16 @@
+Output one status summary entry per single test file/suite.
+
+  $ mkdir -p sub
+
+  $ echo '  $ true' > sub/pass.t
+  $ echo '  $ true' >> sub/pass.t
+
+  $ echo '  $ true' > sub/fail.t
+  $ echo '  $ false' >> sub/fail.t
+
+  $ echo 'No command' > sub/skip.t
+
+  $ grill -quiet sub/*.t
+  !.s
+  # Ran 3 tests, 1 skipped, 1 failed.
+  [1]


### PR DESCRIPTION
This status reporting is consistent with cram.