### PR TITLE
Allow multiline commands without terminating backslashes.

### DIFF
--- a/examples/test.t
+++ b/examples/test.t
@@ -7,10 +7,19 @@ Simple commands:
   baz
 
 Multi-line command:
+
   $ echo foo\
   > bar\
   > baz
   foobarbaz
+
+Multi-line command w/ here-document:
+
+  $ cat <<EOF
+  > Hello, \
+  > world
+  > EOF
+  Hello, world
 
 TODO Persistent bash variables
 # $ foo() {

--- a/internal/grill/grill_test.go
+++ b/internal/grill/grill_test.go
@@ -23,22 +23,22 @@ func makeSpecs() []spec {
 	return []spec{
 		{
 			doc:     "Run grill examples:\n",
-			command: []byte("grill -q examples examples/fail.t"),
+			command: [][]byte{[]byte("grill -q examples examples/fail.t")},
 			results: ".s.!.s.\n# Ran 7 tests, 2 skipped, 1 failed.\n[1]",
 		},
 		{
-			command: []byte("md5 examples/fail.t examples/fail.t.err"),
+			command: [][]byte{[]byte("md5 examples/fail.t examples/fail.t.err")},
 			results: ".*\\b0f598c2b7b8ca5bcb8880e492ff6b452\\b.* (re)\n.*\\b7a23dfa85773c77648f619ad0f9df554\\b.* (re)",
 		},
 		{
-			command: []byte("rm examples/fail.t.err"),
+			command: [][]byte{[]byte("rm examples/fail.t.err")},
 		},
 	}
 }
 
 type spec struct {
 	doc     string
-	command []byte
+	command [][]byte
 	results string
 }
 

--- a/internal/grill/runner_test.go
+++ b/internal/grill/runner_test.go
@@ -12,7 +12,7 @@ func TestRunTest(t *testing.T) {
 		doc: [][]byte{
 			[]byte("This is a test"),
 		},
-		command: []byte("echo foobar"),
+		command: [][]byte{[]byte("echo foobar")},
 		expResults: [][]byte{
 			[]byte("foobar"),
 		},


### PR DESCRIPTION
We can't assume they exist; for example, here-documents do not need
them.