### PR TITLE
Run all tests in a suite in a single script.

### DIFF
--- a/cmd/grill/main.go
+++ b/cmd/grill/main.go
@@ -4,12 +4,19 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/echlebek/grill/internal/grill"
 )
 
 const grillVersion = "dev"
+
+func init() {
+	// Seed rng for test separator string generator.
+	rand.Seed(time.Now().UnixNano())
+}
 
 func main() {
 	os.Exit(Main(os.Args[1:], os.Stdout, os.Stderr))

--- a/examples/test.t
+++ b/examples/test.t
@@ -21,12 +21,13 @@ Multi-line command w/ here-document:
   > EOF
   Hello, world
 
-TODO Persistent bash variables
-# $ foo() {
-# >     echo bar
-# > }
-# $ foo
-# bar
+Shell state persists between commands:
+
+  $ foo() {
+  >     echo bar
+  > }
+  $ foo
+  bar
 
 Regular expression:
 

--- a/internal/grill/runner.go
+++ b/internal/grill/runner.go
@@ -1,6 +1,7 @@
 package grill
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -11,6 +12,9 @@ import (
 	"strings"
 	"syscall"
 )
+
+// Token used to separate output of individual commands in a suite.
+const testBreak = "__GRILL__"
 
 // TestContext specifies an execution environment for running a test.
 type TestContext struct {
@@ -150,10 +154,69 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 		fmt.Sprintf("TESTDIR=%s", testdir),
 	}...)
 
-	for i := 0; i < len(suite.Tests); i++ {
-		if err := suite.Tests[i].Run(ctx); err != nil {
-			return err
+	script := new(bytes.Buffer)
+	for _, t := range suite.Tests {
+		for _, line := range t.command {
+			script.Write(line)
+			script.WriteByte('\n')
 		}
+		// TODO this is currently harcoded for bash, sh, etc
+		script.WriteString(fmt.Sprintf("echo %s$?\n", testBreak))
+	}
+
+	out := new(bytes.Buffer)
+
+	var shellOpts []string
+	if len(ctx.Shell) > 1 {
+		shellOpts = ctx.Shell[1:]
+	}
+	cmd := exec.Command(ctx.Shell[0], shellOpts...)
+	cmd.Stdin = script
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Env = ctx.Environ
+	cmd.Dir = ctx.WorkDir
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("couldn't run command: %s", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		// Last command in each script is the separator that echos return code
+		// and so the script should always exit with zero. If it doesn't, then
+		// it likely exited prematurely (e.g. developer had set -e in it)
+		return fmt.Errorf("test exited with unexpected error: %s", err)
+	}
+
+	i := 0
+	scanner := bufio.NewScanner(out)
+	for scanner.Scan() {
+		t := &suite.Tests[i]
+		line := scanner.Text()
+		tokens := strings.Split(line, testBreak)
+
+		switch len(tokens) {
+		case 1:
+			// Regular output line
+			t.obsResults = append(t.obsResults, []byte(tokens[0]))
+		case 2:
+			// Test break found
+			if len(tokens[0]) > 0 {
+				// Test break line contains the last output line without eol
+				t.obsResults = append(t.obsResults, []byte(tokens[0]+" (no-eol)"))
+			}
+			if exitCode := tokens[1]; exitCode != "0" {
+				t.obsResults = append(t.obsResults, []byte(fmt.Sprintf("[%s]", exitCode)))
+			}
+			t.diff = NewDiff([]byte(t.ExpectedResults()), []byte(t.ObservedResults()))
+			i++
+
+		default:
+			return fmt.Errorf("more than one test break found: %s", line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "reading standard input:", err)
 	}
 
 	if _, err := ctx.Stdout.Write(suite.StatusGlyph()); err != nil {

--- a/internal/grill/runner.go
+++ b/internal/grill/runner.go
@@ -3,6 +3,7 @@ package grill
 import (
 	"bufio"
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -226,15 +227,12 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 	return nil
 }
 
-const digits = "0123456789"
-
-// makeTestBreak generates a randomized line used to separate output of
-// individual commands in a suite. Randomized element is added to reduce
-// the change of the string occurring in the test output itself.
+// makeTestBreak generates a line used to separate output of
+// individual commands in a suite. Randomized element is used
+// to create a string which can be reasonably expected not to
+// occur in the test output itself.
 func makeTestBreak() string {
-	b := make([]byte, 8)
-	for i := range b {
-		b[i] = digits[rand.Intn(len(digits))]
-	}
-	return "GRILL" + string(b) + ":"
+	b := make([]byte, 4)
+	rand.Read(b)
+	return "GRILL" + hex.EncodeToString(b) + ":"
 }

--- a/internal/grill/runner.go
+++ b/internal/grill/runner.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 )
-
-// Token used to separate output of individual commands in a suite.
-const testBreak = "__GRILL__"
 
 // TestContext specifies an execution environment for running a test.
 type TestContext struct {
@@ -154,6 +152,8 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 		fmt.Sprintf("TESTDIR=%s", testdir),
 	}...)
 
+	testBreak := makeTestBreak()
+
 	script := new(bytes.Buffer)
 	for _, t := range suite.Tests {
 		for _, line := range t.command {
@@ -224,4 +224,17 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 	}
 
 	return nil
+}
+
+const digits = "0123456789"
+
+// makeTestBreak generates a randomized line used to separate output of
+// individual commands in a suite. Randomized element is added to reduce
+// the change of the string occurring in the test output itself.
+func makeTestBreak() string {
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = digits[rand.Intn(len(digits))]
+	}
+	return "GRILL" + string(b) + ":"
 }

--- a/internal/grill/runner.go
+++ b/internal/grill/runner.go
@@ -216,7 +216,7 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintln(os.Stderr, "reading standard input:", err)
+		return fmt.Errorf("could not read test output: %s", err)
 	}
 
 	if _, err := ctx.Stdout.Write(suite.StatusGlyph()); err != nil {

--- a/internal/grill/runner_test.go
+++ b/internal/grill/runner_test.go
@@ -7,14 +7,18 @@ import (
 	"testing"
 )
 
-func TestRunTest(t *testing.T) {
-	test := &Test{
-		doc: [][]byte{
-			[]byte("This is a test"),
-		},
-		command: [][]byte{[]byte("echo foobar")},
-		expResults: [][]byte{
-			[]byte("foobar"),
+func TestRunSuite(t *testing.T) {
+	suite := &TestSuite{
+		Tests: []Test{
+			{
+				doc: [][]byte{
+					[]byte("This is a test"),
+				},
+				command: [][]byte{[]byte("echo foobar")},
+				expResults: [][]byte{
+					[]byte("foobar"),
+				},
+			},
 		},
 	}
 
@@ -39,9 +43,11 @@ func TestRunTest(t *testing.T) {
 		Environ: os.Environ(),
 	}
 
-	if err := test.Run(ctx); err != nil {
+	if err := suite.Run(ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	test := &suite.Tests[0]
 
 	if got, want := test.ExpectedResults(), test.ObservedResults(); got != want {
 		t.Errorf("bad test output: got %q, want %q", got, want)


### PR DESCRIPTION
This allows to set and persist shell vars between commands.