### PR TITLE
Enable -preserve-env and -verbose flags; code cleanup.

### DIFF
--- a/cmd/grill/flags.go
+++ b/cmd/grill/flags.go
@@ -24,7 +24,7 @@ var opts = struct {
 }{
 	version:     flags.Bool("version", false, "show version information and exit"),
 	quiet:       flags.Bool("quiet", false, "don't print diffs"),
-	verbose:     flags.Bool("verbose", false, "show filenames and test status (unsupported)"),
+	verbose:     flags.Bool("verbose", false, "show filenames and test status"),
 	interactive: flags.Bool("interactive", false, "interactively merge changed test output (unsupported)"),
 	debug:       flags.Bool("debug", false, "write script output directly to the terminal (unsupported)"),
 	yes:         flags.Bool("yes", false, "answer yes to all questions (unsupported)"),

--- a/internal/grill/grill.go
+++ b/internal/grill/grill.go
@@ -27,16 +27,30 @@ func (t *Test) Skipped() bool {
 	return len(t.command) == 0
 }
 
-// StatusGlyph returns a sequence of characters
-// that represents the suite overall status and gets normally
-// printed by runner to the progress indicator.
-func (suite TestSuite) StatusGlyph() []byte {
+// Status returns a string that represents the suite's overall status.
+//
+// It is normally used by runner to report the run progress.
+func (suite TestSuite) Status() string {
 	if suite.Failed() {
-		return []byte{'!'}
+		return "failed"
 	} else if suite.Skipped() {
-		return []byte{'s'}
+		return "skipped"
 	} else {
-		return []byte{'.'}
+		return "passed"
+	}
+}
+
+// StatusGlyph returns a one character string that
+// represents the suite's overall status.
+//
+// It is normally used by runner to report the run progress.
+func (suite TestSuite) StatusGlyph() string {
+	if suite.Failed() {
+		return "!"
+	} else if suite.Skipped() {
+		return "s"
+	} else {
+		return "."
 	}
 }
 
@@ -113,9 +127,6 @@ func (suite TestSuite) RemoveErr() error {
 // Setting quiet to true will hide the suite diffs
 // and write out just the status summary.
 func WriteReport(w io.Writer, suites []*TestSuite, quiet bool) error {
-	if _, err := w.Write([]byte{'\n'}); err != nil {
-		return err
-	}
 	tests, failed, skipped := 0, 0, 0
 
 	for _, s := range suites {
@@ -136,6 +147,7 @@ func WriteReport(w io.Writer, suites []*TestSuite, quiet bool) error {
 	if tests == 1 {
 		plural = ""
 	}
+
 	_, err := fmt.Fprintf(w, "# Ran %d test%s, %d skipped, %d failed.\n", tests, plural, skipped, failed)
 	return err
 }

--- a/internal/grill/runner_test.go
+++ b/internal/grill/runner_test.go
@@ -1,7 +1,6 @@
 package grill
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -22,8 +21,6 @@ func TestRunSuite(t *testing.T) {
 		},
 	}
 
-	stdout := new(bytes.Buffer)
-
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +34,6 @@ func TestRunSuite(t *testing.T) {
 	}()
 
 	ctx := TestContext{
-		Stdout:  stdout,
 		Shell:   []string{"bash"},
 		WorkDir: dir,
 		Environ: os.Environ(),
@@ -52,5 +48,9 @@ func TestRunSuite(t *testing.T) {
 	join := byteSlicesToString
 	if got, want := join(test.obsResults), join(test.expResults); got != want {
 		t.Errorf("bad test output: got %q, want %q", got, want)
+	}
+
+	if got, want := string(suite.StatusGlyph()), "."; got != want {
+		t.Errorf("bad status output: got %q, want %q", got, want)
 	}
 }

--- a/tests/badtest.t
+++ b/tests/badtest.t
@@ -1,0 +1,6 @@
+Report test parsing errors:
+
+  $ echo '  notacommand' > bad.t
+  $ grill bad.t
+  ** syntax error parsing line 1: expected '$ ' after two spaces (glob)
+  [1]

--- a/tests/preserveenv.t
+++ b/tests/preserveenv.t
@@ -1,0 +1,19 @@
+Don't sterilize environment:
+
+  $ cat > env.t <<EOF
+  >   \$ echo "\$LANG"
+  >   C
+  >   \$ echo "\$TZ"
+  >   foo
+  >   \$ echo "\$CDPATH"
+  >   bar
+  >   \$ echo "\$GREP_OPTIONS"
+  >   baz
+  > EOF
+
+  $ export TZ=foo
+  $ export CDPATH=bar
+  $ export GREP_OPTIONS=baz
+  $ grill -preserve-env env.t
+  .
+  # Ran 1 test, 0 skipped, 0 failed.

--- a/tests/verbose.t
+++ b/tests/verbose.t
@@ -1,0 +1,14 @@
+Verbose mode:
+
+  $ mkdir sub/
+
+  $ echo '  $ true' > sub/a.t
+  $ echo '  $ false' > sub/b.t
+  $ echo '' > sub/c.t
+
+  $ grill -verbose -quiet sub/*
+  sub/a.t: passed
+  sub/b.t: failed
+  sub/c.t: skipped
+  # Ran 3 tests, 1 skipped, 1 failed.
+  [1]


### PR DESCRIPTION
Fix a bug where test reading error was clobbered by one
returned by File.Close()