### PR TITLE
Leave context around each diff change.

### DIFF
--- a/cmd/grill/flags.go
+++ b/cmd/grill/flags.go
@@ -21,6 +21,7 @@ var opts = struct {
 	shellOpts   *string
 	xunitFile   *string
 	indent      *int
+	ctxLen      *int
 }{
 	version:     flags.Bool("version", false, "show version information and exit"),
 	quiet:       flags.Bool("quiet", false, "don't print diffs"),
@@ -35,6 +36,7 @@ var opts = struct {
 	shellOpts:   flags.String("shell-opts", "", "arguments to invoke shell with (unsupported)"),
 	xunitFile:   flags.String("xunit-file", "", "path to write xUnit XML output (unsupported)"),
 	indent:      flags.Int("indent", 2, "number of spaces to use for indentation (unsupported)"),
+	ctxLen:      flags.Int("context-lines", 3, "number of diff context lines to leave around each change"),
 }
 
 func validateOptions() error {

--- a/cmd/grill/main.go
+++ b/cmd/grill/main.go
@@ -133,7 +133,7 @@ func Main(a []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	if err := grill.WriteReport(stdout, suites, *opts.quiet); err != nil {
+	if err := grill.WriteReport(stdout, suites, *opts.ctxLen, *opts.quiet); err != nil {
 		log.Println(err)
 		return 1
 	}

--- a/cmd/grill/main_test.go
+++ b/cmd/grill/main_test.go
@@ -66,7 +66,17 @@ func TestGrillFail(t *testing.T) {
 	if !strings.HasPrefix(stdout, "!\n") {
 		t.Errorf("bad stdout: %q", stdout)
 	}
-	if !strings.HasSuffix(stdout, "@@ -4,1 +4,1 @@\n-  foobaz\n+  foobar\n# Ran 1 test, 0 skipped, 1 failed.\n") {
+
+	expSuffix := `
+@@ -1,4 +1,4 @@
+ Here is another example
+ 
+   $ echo foobar
+-  foobaz
++  foobar
+# Ran 1 test, 0 skipped, 1 failed.
+`
+	if !strings.HasSuffix(stdout, expSuffix) {
 		t.Errorf("bad stdout: %q", stdout)
 	}
 }

--- a/internal/grill/grill.go
+++ b/internal/grill/grill.go
@@ -16,11 +16,11 @@ type Test struct {
 	command    [][]byte
 	expResults [][]byte
 	obsResults [][]byte
-	diff       Diff
+	changes    []*Change
 }
 
 func (t *Test) Failed() bool {
-	return len(t.diff.changes) > 0
+	return len(t.changes) > 0
 }
 
 func (t *Test) Skipped() bool {
@@ -126,14 +126,14 @@ func (suite TestSuite) RemoveErr() error {
 //
 // Setting quiet to true will hide the suite diffs
 // and write out just the status summary.
-func WriteReport(w io.Writer, suites []*TestSuite, quiet bool) error {
+func WriteReport(w io.Writer, suites []*TestSuite, ctxLen int, quiet bool) error {
 	tests, failed, skipped := 0, 0, 0
 
 	for _, s := range suites {
 		if s.Failed() {
 			failed++
 			if !quiet {
-				if err := s.WriteDiff(w); err != nil {
+				if err := s.WriteDiff(w, ctxLen); err != nil {
 					return fmt.Errorf("couldn't write %q: %s", s.Name+".err", err)
 				}
 			}

--- a/internal/grill/runner.go
+++ b/internal/grill/runner.go
@@ -151,7 +151,7 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 			len(status), len(suite.Tests))
 	}
 
-	for i, _ := range suite.Tests {
+	for i := range suite.Tests {
 		t := &suite.Tests[i]
 
 		// Test output
@@ -173,7 +173,7 @@ func (suite *TestSuite) Run(ctx TestContext) error {
 		}
 
 		t.obsResults = lines
-		t.diff = NewDiff(t.expResults, t.obsResults)
+		t.changes = Diff(t.expResults, t.obsResults)
 	}
 
 	return nil

--- a/tests/fail/expected.diff
+++ b/tests/fail/expected.diff
@@ -1,22 +1,36 @@
 !
 --- a.t
 +++ a.t.err
-@@ -4,1 +4,1 @@
+@@ -1,18 +1,18 @@
+ Output needing escaping:
+ 
+   $ printf '\00\01\02\03\04\05\06\07\010\011\013\014\016\017\020\021\022\n'
 -  foo
 +  \x00\x01\x02\x03\x04\x05\x06\a\b\t\v\f\x0e\x0f\x10\x11\x12 (esc)
-@@ -6,1 +6,1 @@
+   $ printf '\023\024\025\026\027\030\031\032\033\034\035\036\037\040\047\n'
 -  bar
 +  \x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f ' (esc)
-@@ -11,1 +11,1 @@
+ 
+ Wrong output and bad regexes:
+ 
+   $ echo 1
 -  2
 +  1
-@@ -13,3 +13,3 @@
+   $ printf '1\nfoo\n1\n'
 -  +++ (re)
 -  foo\ (re)
 -   (re)
 +  1
 +  foo
 +  1
-@@ -22,0 +23,1 @@
+ 
+ Filler to force a second diff hunk:
+ 
+@@ -20,5 +20,6 @@
+ Offset regular expression:
+ 
+   $ printf 'foo\n\n1\n'
 +  foo
+   
+   \d (re)
 # Ran 1 test, 0 skipped, 1 failed.


### PR DESCRIPTION
Create a new Hunk type and construct a sequence of hunks from an input
sequence of changes accounting for overlap in change contexts.

This can likely be made faster at the expense of memory consumption if
we store the original test spec lines so that we don't need to
reconstruct them for .err file & diff output.